### PR TITLE
Add launch hidden option

### DIFF
--- a/nwapp/components/menu-items.js
+++ b/nwapp/components/menu-items.js
@@ -33,6 +33,15 @@ module.exports = [
     support: ['linux', 'win', 'osx']
   },
   {
+    label: 'Start hidden',
+    type: 'checkbox',
+    checked: settings.startHidden,
+    click: function () {
+      settings.startHidden = !settings.startHidden;
+    },
+    support: ['linux', 'win', 'osx']
+  },
+  {
     type: 'separator',
   },
   {
@@ -74,7 +83,7 @@ module.exports = [
     label: 'Exit',
     click: quitApp,
     support: ['linux', 'win']
-  }
+  },
 ].map(function (item, index) {
   item.index = index; // FIXME: unsure whether this is a good way to add index
   return item;

--- a/nwapp/components/menu-items.js
+++ b/nwapp/components/menu-items.js
@@ -33,11 +33,11 @@ module.exports = [
     support: ['linux', 'win', 'osx']
   },
   {
-    label: 'Start hidden',
+    label: 'Launch hidden',
     type: 'checkbox',
-    checked: settings.startHidden,
+    checked: settings.launchHidden,
     click: function () {
-      settings.startHidden = !settings.startHidden;
+      settings.launchHidden = !settings.launchHidden;
     },
     support: ['linux', 'win', 'osx']
   },
@@ -83,7 +83,7 @@ module.exports = [
     label: 'Exit',
     click: quitApp,
     support: ['linux', 'win']
-  },
+  }
 ].map(function (item, index) {
   item.index = index; // FIXME: unsure whether this is a good way to add index
   return item;

--- a/nwapp/index.js
+++ b/nwapp/index.js
@@ -278,7 +278,7 @@ function initApp() {
     });
   });
 
-  if (settings.startHidden !== true) {
+  if (settings.launchHidden !== true) {
     showLoggedInWindow();
   }
 }

--- a/nwapp/index.js
+++ b/nwapp/index.js
@@ -278,7 +278,9 @@ function initApp() {
     });
   });
 
-  showLoggedInWindow();
+  if (settings.startHidden !== true) {
+    showLoggedInWindow();
+  }
 }
 
 function showAuth() {

--- a/nwapp/utils/settings.js
+++ b/nwapp/utils/settings.js
@@ -37,7 +37,11 @@ var DEFAULT_SETTINGS = {
     validate: function (val) {
       return val >= 0 && val <= SOUNDS.length;
     }
-  }
+  },
+  startHidden: {
+    value: false,
+    validate: isBool
+  },
 };
 
 var db = new Store(gui.App.dataPath + '/gitter_preferences.json', { pretty: true }); // FIXME: pretty Boolean - should be environment dependent

--- a/nwapp/utils/settings.js
+++ b/nwapp/utils/settings.js
@@ -24,6 +24,10 @@ var DEFAULT_SETTINGS = {
     value: true,
     validate: isBool
   },
+  launchHidden: {
+    value: false,
+    validate: isBool
+  },
   next: {
     value: false,
     validate: isBool
@@ -37,11 +41,7 @@ var DEFAULT_SETTINGS = {
     validate: function (val) {
       return val >= 0 && val <= SOUNDS.length;
     }
-  },
-  startHidden: {
-    value: false,
-    validate: isBool
-  },
+  }
 };
 
 var db = new Store(gui.App.dataPath + '/gitter_preferences.json', { pretty: true }); // FIXME: pretty Boolean - should be environment dependent


### PR DESCRIPTION
Fix https://github.com/gitterHQ/desktop/issues/107

Based off of https://github.com/gitterHQ/desktop/pull/154
- Renames `startHidden` to `launchHidden` which matches up with the "Launch on startup" language on the other option.

Tested on Windows 10 on startup and launching normally

cc @nicolas33 
